### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/VeritasVault-ai/vv-auth/security/code-scanning/1](https://github.com/VeritasVault-ai/vv-auth/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to restrict the permissions of the `GITHUB_TOKEN`. Since the workflow involves checking out the repository and publishing a package, it requires `contents: read` for accessing the repository and `packages: write` for publishing the package. These permissions adhere to the principle of least privilege.

The `permissions` block will be added at the root of the workflow, ensuring it applies to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflow permissions to improve security and clarify access rights during the publish process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->